### PR TITLE
Update to use flags.IteratorURIFlag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,10 @@ import (
 func main() {
 
 	ctx := context.Background()
-	logger := log.Default()
-
-	err := server.Run(ctx, logger)
+	err := server.Run(ctx)
 
 	if err != nil {
-		logger.Fatal(err)
+		log.Fatal(err)
 	}
 }
 ```
@@ -78,12 +76,10 @@ import (
 func main() {
 
 	ctx := context.Background()
-	logger := log.Default()
-
-	err := server.Run(ctx, logger)
+	err := server.Run(ctx)
 
 	if err != nil {
-		logger.Fatal(err)
+		log.Fatal(err)
 	}
 }
 ```

--- a/app/hierarchy/update/flags.go
+++ b/app/hierarchy/update/flags.go
@@ -8,17 +8,16 @@ import (
 
 	"github.com/sfomuseum/go-flags/flagset"
 	"github.com/sfomuseum/go-flags/multi"
+	spatial_flags "github.com/whosonfirst/go-whosonfirst-spatial/flags"
 )
 
-var iterator_uri string
+var from_iterator_uris spatial_flags.MultiIteratorURIFlag
+var to_iterator_uris spatial_flags.MultiIteratorURIFlag
+
 var exporter_uri string
 var writer_uri string
 
 var spatial_database_uri string
-var spatial_iterator_uri string
-
-var spatial_paths multi.MultiString
-
 var mapshaper_server string
 
 var is_current multi.MultiInt64
@@ -31,16 +30,13 @@ func DefaultFlagSet(ctx context.Context) (*flag.FlagSet, error) {
 
 	fs := flagset.NewFlagSet("pip")
 
-	fs.StringVar(&iterator_uri, "iterator-uri", "repo://", "A valid whosonfirst/go-whosonfirst-iterate/emitter URI scheme. This is used to identify WOF records to be PIP-ed.")
+	fs.Var(&from_iterator_uris, "from-iterator-uri", "...")
+	fs.Var(&to_iterator_uris, "to-iterator-uri", "...")
 
 	fs.StringVar(&exporter_uri, "exporter-uri", "whosonfirst://", "A valid whosonfirst/go-whosonfirst-export URI.")
 	fs.StringVar(&writer_uri, "writer-uri", "null://", "A valid whosonfirst/go-writer URI. This is where updated records will be written to.")
 
 	fs.StringVar(&spatial_database_uri, "spatial-database-uri", "rtree://", "A valid whosonfirst/go-whosonfirst-spatial URI. This is the database of spatial records that will for PIP-ing.")
-
-	fs.StringVar(&spatial_iterator_uri, "spatial-iterator-uri", "repo://", "A valid whosonfirst/go-whosonfirst-iterate/emitter URI scheme. This is used to identify WOF records to be indexed in the spatial database.")
-
-	fs.Var(&spatial_paths, "spatial-source", "One or more URIs to be indexed in the spatial database (used for PIP-ing).")
 
 	// As in github:sfomuseum/go-sfomuseum-mapshaper and github:sfomuseum/docker-sfomuseum-mapshaper
 	// One day the functionality exposed here will be ported to Go and this won't be necessary

--- a/app/hierarchy/update/flags.go
+++ b/app/hierarchy/update/flags.go
@@ -11,8 +11,8 @@ import (
 	spatial_flags "github.com/whosonfirst/go-whosonfirst-spatial/flags"
 )
 
-var from_iterator_uris spatial_flags.MultiIteratorURIFlag
-var to_iterator_uris spatial_flags.MultiIteratorURIFlag
+var source_iterator_uris spatial_flags.MultiIteratorURIFlag
+var target_iterator_uris spatial_flags.MultiIteratorURIFlag
 
 var exporter_uri string
 var writer_uri string
@@ -30,8 +30,8 @@ func DefaultFlagSet(ctx context.Context) (*flag.FlagSet, error) {
 
 	fs := flagset.NewFlagSet("pip")
 
-	fs.Var(&from_iterator_uris, "from-iterator-uri", "...")
-	fs.Var(&to_iterator_uris, "to-iterator-uri", "...")
+	fs.Var(&source_iterator_uris, "source-iterator-uri", "...")
+	fs.Var(&target_iterator_uris, "target-iterator-uri", "...")
 
 	fs.StringVar(&exporter_uri, "exporter-uri", "whosonfirst://", "A valid whosonfirst/go-whosonfirst-export URI.")
 	fs.StringVar(&writer_uri, "writer-uri", "null://", "A valid whosonfirst/go-writer URI. This is where updated records will be written to.")

--- a/app/hierarchy/update/flags.go
+++ b/app/hierarchy/update/flags.go
@@ -30,8 +30,13 @@ func DefaultFlagSet(ctx context.Context) (*flag.FlagSet, error) {
 
 	fs := flagset.NewFlagSet("pip")
 
-	fs.Var(&source_iterator_uris, "source-iterator-uri", "...")
-	fs.Var(&target_iterator_uris, "target-iterator-uri", "...")
+	desc_iter := spatial_flags.IteratorURIFlagDescription()
+
+	source_desc := fmt.Sprintf("Zero or more URIs denoting data sources to use for indexing the spatial database at startup. %s", desc_iter)
+	target_desc := fmt.Sprintf("Zero or more URIs denoting target data sources whose hierarchies need updating. %s", desc_iter)
+
+	fs.Var(&source_iterator_uris, "source-iterator-uri", source_desc)
+	fs.Var(&target_iterator_uris, "target-iterator-uri", target_desc)
 
 	fs.StringVar(&exporter_uri, "exporter-uri", "whosonfirst://", "A valid whosonfirst/go-whosonfirst-export URI.")
 	fs.StringVar(&writer_uri, "writer-uri", "null://", "A valid whosonfirst/go-writer URI. This is where updated records will be written to.")

--- a/app/hierarchy/update/options.go
+++ b/app/hierarchy/update/options.go
@@ -14,20 +14,20 @@ import (
 )
 
 type RunOptions struct {
-	Writer             writer.Writer
-	WriterURI          string
-	Exporter           export.Exporter
-	ExporterURI        string
-	MapshaperServerURI string
-	SpatialDatabase    database.SpatialDatabase
-	SpatialDatabaseURI string
-	ToIterator         string
-	FromIterator       string
-	SPRFilterInputs    *filter.SPRInputs
-	SPRResultsFunc     hierarchy_filter.FilterSPRResultsFunc                   // This one chooses one result among many (or nil)
-	PIPUpdateFunc      hierarchy.PointInPolygonHierarchyResolverUpdateCallback // This one constructs a map[string]interface{} to update the target record (or not)
-	To                 []string
-	From               []string
+	Writer              writer.Writer
+	WriterURI           string
+	Exporter            export.Exporter
+	ExporterURI         string
+	MapshaperServerURI  string
+	SpatialDatabase     database.SpatialDatabase
+	SpatialDatabaseURI  string
+	ToIteratorSources   map[string][]string
+	FromIteratorSources map[string][]string
+	SPRFilterInputs     *filter.SPRInputs
+	SPRResultsFunc      hierarchy_filter.FilterSPRResultsFunc                   // This one chooses one result among many (or nil)
+	PIPUpdateFunc       hierarchy.PointInPolygonHierarchyResolverUpdateCallback // This one constructs a map[string]interface{} to update the target record (or not)
+	To                  []string
+	From                []string
 }
 
 func RunOptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, error) {
@@ -42,8 +42,6 @@ func RunOptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, 
 	inputs.IsSuperseded = is_superseded
 	inputs.IsSuperseding = is_superseding
 
-	hierarchy_paths := fs.Args()
-
 	opts := &RunOptions{
 		WriterURI:          writer_uri,
 		ExporterURI:        exporter_uri,
@@ -51,10 +49,14 @@ func RunOptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, 
 		MapshaperServerURI: mapshaper_server,
 		SPRResultsFunc:     hierarchy_filter.FirstButForgivingSPRResultsFunc, // sudo make me configurable
 		SPRFilterInputs:    inputs,
-		ToIterator:         iterator_uri,
-		FromIterator:       spatial_iterator_uri,
-		To:                 hierarchy_paths,
-		From:               spatial_paths,
+	}
+
+	if len(from_iterator_uris) > 0 {
+		opts.FromIteratorSources = from_iterator_uris.AsMap()
+	}
+
+	if len(to_iterator_uris) > 0 {
+		opts.ToIteratorSources = to_iterator_uris.AsMap()
 	}
 
 	return opts, nil

--- a/app/hierarchy/update/options.go
+++ b/app/hierarchy/update/options.go
@@ -14,20 +14,18 @@ import (
 )
 
 type RunOptions struct {
-	Writer              writer.Writer
-	WriterURI           string
-	Exporter            export.Exporter
-	ExporterURI         string
-	MapshaperServerURI  string
-	SpatialDatabase     database.SpatialDatabase
-	SpatialDatabaseURI  string
-	ToIteratorSources   map[string][]string
-	FromIteratorSources map[string][]string
-	SPRFilterInputs     *filter.SPRInputs
-	SPRResultsFunc      hierarchy_filter.FilterSPRResultsFunc                   // This one chooses one result among many (or nil)
-	PIPUpdateFunc       hierarchy.PointInPolygonHierarchyResolverUpdateCallback // This one constructs a map[string]interface{} to update the target record (or not)
-	To                  []string
-	From                []string
+	Writer                writer.Writer
+	WriterURI             string
+	Exporter              export.Exporter
+	ExporterURI           string
+	MapshaperServerURI    string
+	SpatialDatabase       database.SpatialDatabase
+	SpatialDatabaseURI    string
+	TargetIteratorSources map[string][]string
+	SourceIteratorSources map[string][]string
+	SPRFilterInputs       *filter.SPRInputs
+	SPRResultsFunc        hierarchy_filter.FilterSPRResultsFunc                   // This one chooses one result among many (or nil)
+	PIPUpdateFunc         hierarchy.PointInPolygonHierarchyResolverUpdateCallback // This one constructs a map[string]interface{} to update the target record (or not)
 }
 
 func RunOptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, error) {
@@ -51,12 +49,12 @@ func RunOptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, 
 		SPRFilterInputs:    inputs,
 	}
 
-	if len(from_iterator_uris) > 0 {
-		opts.FromIteratorSources = from_iterator_uris.AsMap()
+	if len(source_iterator_uris) > 0 {
+		opts.SourceIteratorSources = source_iterator_uris.AsMap()
 	}
 
-	if len(to_iterator_uris) > 0 {
-		opts.ToIteratorSources = to_iterator_uris.AsMap()
+	if len(target_iterator_uris) > 0 {
+		opts.TargetIteratorSources = target_iterator_uris.AsMap()
 	}
 
 	return opts, nil

--- a/app/hierarchy/update/update.go
+++ b/app/hierarchy/update/update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 
 	"github.com/sfomuseum/go-sfomuseum-mapshaper"
 	"github.com/whosonfirst/go-whosonfirst-export/v2"
@@ -13,7 +12,7 @@ import (
 	"github.com/whosonfirst/go-writer/v3"
 )
 
-func Run(ctx context.Context, logger *log.Logger) error {
+func Run(ctx context.Context) error {
 
 	fs, err := DefaultFlagSet(ctx)
 
@@ -21,10 +20,10 @@ func Run(ctx context.Context, logger *log.Logger) error {
 		fmt.Errorf("Failed to create application flag set, %w", err)
 	}
 
-	return RunWithFlagSet(ctx, fs, logger)
+	return RunWithFlagSet(ctx, fs)
 }
 
-func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *log.Logger) error {
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
 
 	opts, err := RunOptionsFromFlagSet(ctx, fs)
 
@@ -32,10 +31,10 @@ func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *log.Logger) e
 		return fmt.Errorf("Failed to derive run options, %w", err)
 	}
 
-	return RunWithOptions(ctx, opts, logger)
+	return RunWithOptions(ctx, opts)
 }
 
-func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) error {
+func RunWithOptions(ctx context.Context, opts *RunOptions) error {
 
 	// Note that the bulk of this method is simply taking opts and using it to
 	// instantiate all the different pieces necessary for the updateApplication

--- a/app/hierarchy/update/update.go
+++ b/app/hierarchy/update/update.go
@@ -140,11 +140,7 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 		return fmt.Errorf("Failed to create PIP tool, %v", err)
 	}
 
-	// This is where the actual work happens
-
 	app := &updateApplication{
-		to:                  opts.ToIterator,
-		from:                opts.FromIterator,
 		spatial_db:          spatial_db,
 		resolver:            resolver,
 		exporter:            ex,
@@ -155,10 +151,5 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 		hierarchyUpdateFunc: update_cb,
 	}
 
-	paths := &updateApplicationPaths{
-		To:   opts.To,
-		From: opts.From,
-	}
-
-	return app.Run(ctx, paths)
+	return app.Run(ctx, opts.FromIteratorSources, opts.ToIteratorSources)
 }

--- a/app/hierarchy/update/update.go
+++ b/app/hierarchy/update/update.go
@@ -151,5 +151,5 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 		hierarchyUpdateFunc: update_cb,
 	}
 
-	return app.Run(ctx, opts.FromIteratorSources, opts.ToIteratorSources)
+	return app.Run(ctx, opts.SourceIteratorSources, opts.TargetIteratorSources)
 }

--- a/app/hierarchy/update/update_app.go
+++ b/app/hierarchy/update/update_app.go
@@ -7,7 +7,7 @@ import (
 	_ "log/slog"
 
 	"github.com/whosonfirst/go-whosonfirst-export/v2"
-	"github.com/whosonfirst/go-whosonfirst-feature/geometry"
+	"github.com/whosonfirst/go-whosonfirst-iterate/v2/emitter"
 	"github.com/whosonfirst/go-whosonfirst-iterate/v2/iterator"
 	"github.com/whosonfirst/go-whosonfirst-spatial/database"
 	"github.com/whosonfirst/go-whosonfirst-spatial/filter"
@@ -17,17 +17,10 @@ import (
 	"github.com/whosonfirst/go-writer/v3"
 )
 
-type updateApplicationPaths struct {
-	To   []string
-	From []string
-}
-
 // updateApplication is a struct to wrap the details of (optionally) populating a spatial
 // database and updating the hierarchies of (n) files derived from an iterator including
 // writing (publishing) the updated records.
 type updateApplication struct {
-	to                  string
-	from                string
 	resolver            *hierarchy.PointInPolygonHierarchyResolver
 	writer              writer.Writer
 	exporter            export.Exporter
@@ -38,17 +31,15 @@ type updateApplication struct {
 	hierarchyUpdateFunc hierarchy.PointInPolygonHierarchyResolverUpdateCallback
 }
 
-func (app *updateApplication) Run(ctx context.Context, paths *updateApplicationPaths) error {
+func (app *updateApplication) Run(ctx context.Context, from map[string][]string, to map[string][]string) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// These are the data we are indexing to HIERARCHY from
 
-	err := app.indexSpatialDatabase(ctx, paths.From...)
-
-	if err != nil {
-		return err
+	from_cb := func(ctx context.Context, path string, r io.ReadSeeker, args ...interface{}) error {
+		return database.IndexDatabaseWithReader(ctx, app.spatial_db, r)
 	}
 
 	// These are the data we are HIERARCHY-ing
@@ -70,13 +61,33 @@ func (app *updateApplication) Run(ctx context.Context, paths *updateApplicationP
 		return nil
 	}
 
-	to_iter, err := iterator.NewIterator(ctx, app.to, to_cb)
+	iterate := func(ctx context.Context, sources map[string][]string, cb emitter.EmitterCallbackFunc) error {
 
-	if err != nil {
-		return fmt.Errorf("Failed to create new HIERARCHY (to) iterator for input, %v", err)
+		for iter_uri, iter_sources := range sources {
+
+			iter, err := iterator.NewIterator(ctx, iter_uri, from_cb)
+
+			if err != nil {
+				return fmt.Errorf("Failed to create iterator for %s, %w", iter_uri, err)
+			}
+
+			err = iter.IterateURIs(ctx, iter_sources...)
+
+			if err != nil {
+				return fmt.Errorf("Failed to iterate sources for %s, %w", iter_uri, err)
+			}
+		}
+
+		return nil
 	}
 
-	err = to_iter.IterateURIs(ctx, paths.To...)
+	err := iterate(ctx, from, from_cb)
+
+	if err != nil {
+		return err
+	}
+
+	err = iterate(ctx, to, to_cb)
 
 	if err != nil {
 		return err
@@ -87,45 +98,6 @@ func (app *updateApplication) Run(ctx context.Context, paths *updateApplicationP
 	// (20210219/thisisaaronland)
 
 	return app.writer.Close(ctx)
-}
-
-func (app *updateApplication) indexSpatialDatabase(ctx context.Context, uris ...string) error {
-
-	from_cb := func(ctx context.Context, path string, fh io.ReadSeeker, args ...interface{}) error {
-
-		body, err := io.ReadAll(fh)
-
-		if err != nil {
-			return fmt.Errorf("Failed to read %s, %w", path, err)
-		}
-
-		geom_type, err := geometry.Type(body)
-
-		if err != nil {
-			return fmt.Errorf("Failed to derive geometry type for %s, %w", path, err)
-		}
-
-		switch geom_type {
-		case "Polygon", "MultiPolygon":
-			return app.spatial_db.IndexFeature(ctx, body)
-		default:
-			return nil
-		}
-	}
-
-	from_iter, err := iterator.NewIterator(ctx, app.from, from_cb)
-
-	if err != nil {
-		return fmt.Errorf("Failed to create spatial (from) iterator, %v", err)
-	}
-
-	err = from_iter.IterateURIs(ctx, uris...)
-
-	if err != nil {
-		return fmt.Errorf("Failed to iteratre URIs, %w", err)
-	}
-
-	return nil
 }
 
 // UpdateAndPublishFeature will invoke the `PointInPolygonAndUpdate` method using the `hierarchy.PointInPolygonHierarchyResolver` instance

--- a/app/pip/flags.go
+++ b/app/pip/flags.go
@@ -10,7 +10,7 @@ import (
 	"github.com/whosonfirst/go-reader"
 	"github.com/whosonfirst/go-whosonfirst-iterate/v2/emitter"
 	"github.com/whosonfirst/go-whosonfirst-spatial/database"
-	spatial_flags "github.com/whosonfirst/go-whosonfirst-spatial/flags"	
+	spatial_flags "github.com/whosonfirst/go-whosonfirst-spatial/flags"
 	"sort"
 	"strings"
 )
@@ -48,7 +48,7 @@ var verbose bool
 
 var sort_uris multi.MultiString
 
-var iterator_uris spatial_flags.MultiIteratorURIFlag	// multi.MultiCSVString
+var iterator_uris spatial_flags.MultiIteratorURIFlag
 
 func DefaultFlagSet(ctx context.Context) (*flag.FlagSet, error) {
 

--- a/app/pip/flags.go
+++ b/app/pip/flags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/whosonfirst/go-reader"
 	"github.com/whosonfirst/go-whosonfirst-iterate/v2/emitter"
 	"github.com/whosonfirst/go-whosonfirst-spatial/database"
+	spatial_flags "github.com/whosonfirst/go-whosonfirst-spatial/flags"	
 	"sort"
 	"strings"
 )
@@ -47,7 +48,7 @@ var verbose bool
 
 var sort_uris multi.MultiString
 
-var iterator_uris multi.MultiCSVString
+var iterator_uris spatial_flags.MultiIteratorURIFlag	// multi.MultiCSVString
 
 func DefaultFlagSet(ctx context.Context) (*flag.FlagSet, error) {
 

--- a/app/pip/flags.go
+++ b/app/pip/flags.go
@@ -8,11 +8,8 @@ import (
 	"github.com/sfomuseum/go-flags/flagset"
 	"github.com/sfomuseum/go-flags/multi"
 	"github.com/whosonfirst/go-reader"
-	"github.com/whosonfirst/go-whosonfirst-iterate/v2/emitter"
 	"github.com/whosonfirst/go-whosonfirst-spatial/database"
 	spatial_flags "github.com/whosonfirst/go-whosonfirst-spatial/flags"
-	"sort"
-	"strings"
 )
 
 var spatial_database_uri string
@@ -97,13 +94,10 @@ func DefaultFlagSet(ctx context.Context) (*flag.FlagSet, error) {
 
 	// Indexing flags
 
-	modes := emitter.Schemes()
-	sort.Strings(modes)
+	desc_iter := spatial_flags.IteratorURIFlagDescription()
+	desc_iter = fmt.Sprintf("Zero or more URIs denoting data sources to use for indexing the spatial database at startup. %s", desc_iter)
 
-	valid_modes := strings.Join(modes, ", ")
-	desc_modes := fmt.Sprintf("Zero or more URIs denoting data sources to use for indexing the spatial database at startup. URIs take the form of {ITERATOR_URI} + \"#\" + {PIPE-SEPARATED LIST OF ITERATOR SOURCES}. Where {ITERATOR_URI} is expected to be a registered whosonfirst/go-whosonfirst-iterate/v2 iterator (emitter) URI and {ITERATOR SOURCES} are valid input paths for that iterator. Supported whosonfirst/go-whosonfirst-iterate/v2 iterator schemes are: %s.", valid_modes)
-
-	fs.Var(&iterator_uris, "iterator-uri", desc_modes)
+	fs.Var(&iterator_uris, "iterator-uri", desc_iter)
 
 	// Runtime / server flags
 

--- a/app/pip/flags.go
+++ b/app/pip/flags.go
@@ -47,7 +47,7 @@ var verbose bool
 
 var sort_uris multi.MultiString
 
-var iterator_uri string
+var iterator_uris multi.MultiCSVString
 
 func DefaultFlagSet(ctx context.Context) (*flag.FlagSet, error) {
 
@@ -100,9 +100,9 @@ func DefaultFlagSet(ctx context.Context) (*flag.FlagSet, error) {
 	sort.Strings(modes)
 
 	valid_modes := strings.Join(modes, ", ")
-	desc_modes := fmt.Sprintf("A valid whosonfirst/go-whosonfirst-iterate/v2 URI. Supported schemes are: %s.", valid_modes)
+	desc_modes := fmt.Sprintf("Zero or more URIs denoting data sources to use for indexing the spatial database at startup. URIs take the form of {ITERATOR_URI} + \"#\" + {PIPE-SEPARATED LIST OF ITERATOR SOURCES}. Where {ITERATOR_URI} is expected to be a registered whosonfirst/go-whosonfirst-iterate/v2 iterator (emitter) URI and {ITERATOR SOURCES} are valid input paths for that iterator. Supported whosonfirst/go-whosonfirst-iterate/v2 iterator schemes are: %s.", valid_modes)
 
-	fs.StringVar(&iterator_uri, "iterator-uri", "repo://", desc_modes)
+	fs.Var(&iterator_uris, "iterator-uri", desc_modes)
 
 	// Runtime / server flags
 

--- a/app/pip/options.go
+++ b/app/pip/options.go
@@ -3,34 +3,35 @@ package pip
 import (
 	"context"
 	"flag"
+	"log/slog"
+	"strings"
 
 	"github.com/sfomuseum/go-flags/flagset"
 )
 
 type RunOptions struct {
-	Mode                   string   `json:"mode"`
-	Verbose                bool     `json:"verbose"`
-	Sources                []string `json:"sources"`
-	SpatialDatabaseURI     string   `json:"spatial_database_uri"`
-	PropertiesReaderURI    string   `json:"properties_reader_uri"`
-	IteratorURI            string   `json:"iterator_uri"`
-	EnableCustomPlacetypes bool     `json:"enable_custom_placetypes"`
-	CustomPlacetypes       string   `json:"custom_placetypes"`
-	IsWhosOnFirst          bool     `json:"is_whosonfirst"`
-	Latitude               float64  `json:"latitude"`
-	Longitude              float64  `json:"longitude"`
-	Placetypes             []string `json:"placetypes,omitempty"`
-	Geometries             string   `json:"geometries,omitempty"`
-	AlternateGeometries    []string `json:"alternate_geometries,omitempty"`
-	IsCurrent              []int64  `json:"is_current,omitempty"`
-	IsCeased               []int64  `json:"is_ceased,omitempty"`
-	IsDeprecated           []int64  `json:"is_deprecated,omitempty"`
-	IsSuperseded           []int64  `json:"is_superseded,omitempty"`
-	IsSuperseding          []int64  `json:"is_superseding,omitempty"`
-	InceptionDate          string   `json:"inception_date,omitempty"`
-	CessationDate          string   `json:"cessation_date,omitempty"`
-	Properties             []string `json:"properties,omitempty"`
-	Sort                   []string `json:"sort,omitempty"`
+	Mode                   string              `json:"mode"`
+	Verbose                bool                `json:"verbose"`
+	IteratorSources        map[string][]string `json:"iterator_sources"`
+	SpatialDatabaseURI     string              `json:"spatial_database_uri"`
+	PropertiesReaderURI    string              `json:"properties_reader_uri"`
+	EnableCustomPlacetypes bool                `json:"enable_custom_placetypes"`
+	CustomPlacetypes       string              `json:"custom_placetypes"`
+	IsWhosOnFirst          bool                `json:"is_whosonfirst"`
+	Latitude               float64             `json:"latitude"`
+	Longitude              float64             `json:"longitude"`
+	Placetypes             []string            `json:"placetypes,omitempty"`
+	Geometries             string              `json:"geometries,omitempty"`
+	AlternateGeometries    []string            `json:"alternate_geometries,omitempty"`
+	IsCurrent              []int64             `json:"is_current,omitempty"`
+	IsCeased               []int64             `json:"is_ceased,omitempty"`
+	IsDeprecated           []int64             `json:"is_deprecated,omitempty"`
+	IsSuperseded           []int64             `json:"is_superseded,omitempty"`
+	IsSuperseding          []int64             `json:"is_superseding,omitempty"`
+	InceptionDate          string              `json:"inception_date,omitempty"`
+	CessationDate          string              `json:"cessation_date,omitempty"`
+	Properties             []string            `json:"properties,omitempty"`
+	Sort                   []string            `json:"sort,omitempty"`
 }
 
 func RunOptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, error) {
@@ -43,15 +44,11 @@ func RunOptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, 
 		return nil, err
 	}
 
-	iterator_sources := fs.Args()
-
 	opts := &RunOptions{
 		Mode:                   mode,
 		Verbose:                verbose,
-		Sources:                iterator_sources,
 		SpatialDatabaseURI:     spatial_database_uri,
 		PropertiesReaderURI:    properties_reader_uri,
-		IteratorURI:            iterator_uri,
 		EnableCustomPlacetypes: enable_custom_placetypes,
 		CustomPlacetypes:       custom_placetypes,
 		IsWhosOnFirst:          is_wof,
@@ -70,6 +67,25 @@ func RunOptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, 
 		CessationDate:       cessation,
 		Properties:          props,
 		Sort:                sort_uris,
+	}
+
+	if len(iterator_uris) > 0 {
+
+		iter_sources := make(map[string][]string)
+
+		for _, uri := range iterator_uris {
+
+			parts := strings.Split(uri, "#")
+
+			switch len(parts) {
+			case 2:
+				iter_sources[parts[0]] = strings.Split(parts[1], "|")
+			default:
+				slog.Warn("Invalid iterator_uri", "uri", uri, "count", len(parts))
+			}
+		}
+
+		opts.IteratorSources = iter_sources
 	}
 
 	return opts, nil

--- a/app/pip/options.go
+++ b/app/pip/options.go
@@ -3,8 +3,8 @@ package pip
 import (
 	"context"
 	"flag"
-	"log/slog"
-	"strings"
+	// "log/slog"
+	// "strings"
 
 	"github.com/sfomuseum/go-flags/flagset"
 )
@@ -71,21 +71,7 @@ func RunOptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, 
 
 	if len(iterator_uris) > 0 {
 
-		iter_sources := make(map[string][]string)
-
-		for _, uri := range iterator_uris {
-
-			parts := strings.Split(uri, "#")
-
-			switch len(parts) {
-			case 2:
-				iter_sources[parts[0]] = strings.Split(parts[1], "|")
-			default:
-				slog.Warn("Invalid iterator_uri", "uri", uri, "count", len(parts))
-			}
-		}
-
-		opts.IteratorSources = iter_sources
+		opts.IteratorSources = iterator_uris.AsMap()
 	}
 
 	return opts, nil

--- a/app/pip/pip.go
+++ b/app/pip/pip.go
@@ -45,7 +45,6 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 		PropertiesReaderURI:    opts.PropertiesReaderURI,
 		EnableCustomPlacetypes: opts.EnableCustomPlacetypes,
 		CustomPlacetypes:       opts.CustomPlacetypes,
-		IsWhosOnFirst:          opts.IsWhosOnFirst,
 	}
 
 	spatial_app, err := app.NewSpatialApplication(ctx, spatial_opts)

--- a/app/pip/pip.go
+++ b/app/pip/pip.go
@@ -43,7 +43,7 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 	spatial_opts := &app.SpatialApplicationOptions{
 		SpatialDatabaseURI:     opts.SpatialDatabaseURI,
 		PropertiesReaderURI:    opts.PropertiesReaderURI,
-		IteratorURI:            opts.IteratorURI,
+		// IteratorURI:            opts.IteratorURI,
 		EnableCustomPlacetypes: opts.EnableCustomPlacetypes,
 		CustomPlacetypes:       opts.CustomPlacetypes,
 		IsWhosOnFirst:          opts.IsWhosOnFirst,
@@ -55,6 +55,7 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 		return fmt.Errorf("Failed to create new spatial application, %w", err)
 	}
 
+	/*
 	done_ch := make(chan bool)
 
 	go func() {
@@ -67,14 +68,15 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 
 		done_ch <- true
 	}()
-
+	*/
+	
 	switch mode {
 
 	case "cli":
 
 		props := opts.Properties
 
-		<-done_ch
+		// <-done_ch
 
 		req := &pip.PointInPolygonRequest{
 			Latitude:            opts.Latitude,
@@ -130,7 +132,7 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 
 	case "lambda":
 
-		<-done_ch
+		// <-done_ch
 
 		handler := func(ctx context.Context, req *pip.PointInPolygonRequest) (interface{}, error) {
 			return pip.QueryPointInPolygon(ctx, spatial_app, req)

--- a/app/pip/pip.go
+++ b/app/pip/pip.go
@@ -43,7 +43,6 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 	spatial_opts := &app.SpatialApplicationOptions{
 		SpatialDatabaseURI:     opts.SpatialDatabaseURI,
 		PropertiesReaderURI:    opts.PropertiesReaderURI,
-		// IteratorURI:            opts.IteratorURI,
 		EnableCustomPlacetypes: opts.EnableCustomPlacetypes,
 		CustomPlacetypes:       opts.CustomPlacetypes,
 		IsWhosOnFirst:          opts.IsWhosOnFirst,
@@ -55,12 +54,11 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 		return fmt.Errorf("Failed to create new spatial application, %w", err)
 	}
 
-	/*
 	done_ch := make(chan bool)
 
 	go func() {
 
-		err := spatial_app.Iterator.IterateURIs(ctx, opts.Sources...)
+		err := spatial_app.IndexDatabaseWithIterators(ctx, opts.IteratorSources)
 
 		if err != nil {
 			logger.Printf("Failed to iterate URIs, %v", err)
@@ -68,15 +66,14 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 
 		done_ch <- true
 	}()
-	*/
-	
+
 	switch mode {
 
 	case "cli":
 
 		props := opts.Properties
 
-		// <-done_ch
+		<-done_ch
 
 		req := &pip.PointInPolygonRequest{
 			Latitude:            opts.Latitude,
@@ -132,7 +129,7 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 
 	case "lambda":
 
-		// <-done_ch
+		<-done_ch
 
 		handler := func(ctx context.Context, req *pip.PointInPolygonRequest) (interface{}, error) {
 			return pip.QueryPointInPolygon(ctx, spatial_app, req)

--- a/app/pip/pip.go
+++ b/app/pip/pip.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/whosonfirst/go-whosonfirst-spatial"
@@ -13,7 +13,7 @@ import (
 	"github.com/whosonfirst/go-whosonfirst-spatial/pip"
 )
 
-func Run(ctx context.Context, logger *log.Logger) error {
+func Run(ctx context.Context) error {
 
 	fs, err := DefaultFlagSet(ctx)
 
@@ -21,10 +21,10 @@ func Run(ctx context.Context, logger *log.Logger) error {
 		return fmt.Errorf("Failed to create application flag set, %v", err)
 	}
 
-	return RunWithFlagSet(ctx, fs, logger)
+	return RunWithFlagSet(ctx, fs)
 }
 
-func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *log.Logger) error {
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
 
 	opts, err := RunOptionsFromFlagSet(ctx, fs)
 
@@ -32,10 +32,10 @@ func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *log.Logger) e
 		return fmt.Errorf("Failed to derive options from flagset, %w", err)
 	}
 
-	return RunWithOptions(ctx, opts, logger)
+	return RunWithOptions(ctx, opts)
 }
 
-func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) error {
+func RunWithOptions(ctx context.Context, opts *RunOptions) error {
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -60,7 +60,7 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *log.Logger) e
 		err := spatial_app.IndexDatabaseWithIterators(ctx, opts.IteratorSources)
 
 		if err != nil {
-			logger.Printf("Failed to iterate URIs, %v", err)
+			slog.Error("Failed to index database", "error", err)
 		}
 
 		done_ch <- true

--- a/application/application.go
+++ b/application/application.go
@@ -218,7 +218,7 @@ func (p *SpatialApplication) IndexDatabaseWithIterators(ctx context.Context, sou
 		err = iter.IterateURIs(ctx, iter_sources...)
 
 		if err != nil {
-			return fmt.Errorf("Failed to iterate sources for %s (%w), %w", iter_uri, iter_sources, err)
+			return fmt.Errorf("Failed to iterate sources for %s (%v), %w", iter_uri, iter_sources, err)
 		}
 
 		debug.FreeOSMemory()

--- a/application/application.go
+++ b/application/application.go
@@ -7,20 +7,16 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	// "os"
 	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
-	// "time"
 
 	"github.com/sfomuseum/go-timings"
 	"github.com/whosonfirst/go-reader"
-	// "github.com/whosonfirst/go-whosonfirst-feature/geometry"
 	"github.com/whosonfirst/go-whosonfirst-iterate/v2/iterator"
 	"github.com/whosonfirst/go-whosonfirst-placetypes"
 	"github.com/whosonfirst/go-whosonfirst-spatial/database"
-	// "github.com/whosonfirst/warning"
 )
 
 // SpatialApplication a bunch of different operations related to indexing and querying spatial
@@ -34,20 +30,17 @@ import (
 //   - A new `reader.Reader` instance is created and made available a public 'PropertiesReader' property. This reader
 //     is intended for use by methods like `PropertiesResponseResultsWithStandardPlacesResults` which is what appends
 //     custom  properties to SPR responses (for example, in a point-in-polygon result set).
-//   - A new `iterator.Iterator` instance is created with a default callback to index records in `SpatialDatabase' and
-//     made available as a public 'Iterator' property.
 //   - If custom placetypes are defined these will be loaded an appended to the default `whosonfirst/go-whosonfirst-placetype`
 //     specification. This can be useful if you are working with non-standard Who's On First style records that define
 //     their own placetypes.
 type SpatialApplication struct {
 	SpatialDatabase  database.SpatialDatabase
 	PropertiesReader reader.Reader
-	/* Iterator         *iterator.Iterator */
-	Timings  []*timings.SinceResponse
-	Monitor  timings.Monitor
-	mu       *sync.RWMutex
-	indexing int64
-	indexed  int64
+	Timings          []*timings.SinceResponse
+	Monitor          timings.Monitor
+	mu               *sync.RWMutex
+	indexing         int64
+	indexed          int64
 }
 
 // SpatialApplicationOptions defines properties used to instantiate a new `SpatialApplication` instance.
@@ -56,13 +49,6 @@ type SpatialApplicationOptions struct {
 	SpatialDatabaseURI string
 	// A valid `whosonfirst/go-reader` URI.
 	PropertiesReaderURI string
-
-	// A valid `whosonfirst/go-whosonfirst-iterator/v2` URI.
-	// IteratorURI string
-
-	// IsWhosOnFirst signals that input files (to index) are assumed to be valid Who's On First records
-	// and not arbitrary GeoJSON
-	IsWhosOnFirst bool
 	// EnableCustomPlacetypes signals that custom placetypes should be appended to the default placetype specification.
 	EnableCustomPlacetypes bool
 	// A JSON-encoded `whosonfirst/go-whosonfirst-placetypes.WOFPlacetypeSpecification` definition with custom placetypes.
@@ -102,69 +88,6 @@ func NewSpatialApplication(ctx context.Context, opts *SpatialApplicationOptions)
 	if properties_reader == nil {
 		properties_reader = spatial_db
 	}
-
-	// Set up iterator (to index records at start up if necessary)
-
-	/*
-
-		iter_cb := func(ctx context.Context, path string, r io.ReadSeeker, args ...interface{}) error {
-
-			body, err := io.ReadAll(r)
-
-			if err != nil {
-				return fmt.Errorf("Failed to read '%s', %w", path, err)
-			}
-
-			if opts.IsWhosOnFirst {
-
-				if err != nil {
-
-					// it's still not clear (to me) what the expected or desired
-					// behaviour is / in this instance we might be issuing a warning
-					// from the geojson-v2 package because a feature might have a
-					// placetype defined outside of "core" (in the go-whosonfirst-placetypes)
-					// package but that shouldn't necessarily trigger a fatal error
-					// (20180405/thisisaaronland)
-
-					if !warning.IsWarning(err) {
-						return err
-					}
-
-					slog.Warn("Feature triggered the following warning", "path", path, "error", err)
-				}
-			}
-
-			geom_type, err := geometry.Type(body)
-
-			if err != nil {
-				return fmt.Errorf("Failed to derive geometry type for %s, %w", path, err)
-			}
-
-			if geom_type == "Point" {
-				return nil
-			}
-
-			err = spatial_db.IndexFeature(ctx, body)
-
-			if err != nil {
-
-				// something something something wrapping errors in Go 1.13
-				// something something something waiting to see if the GOPROXY is
-				// disabled by default in Go > 1.13 (20190919/thisisaaronland)
-
-				return fmt.Errorf("Failed to index %s %d", path, err)
-			}
-
-			return nil
-		}
-
-		iter, err := iterator.NewIterator(ctx, opts.IteratorURI, iter_cb)
-
-		if err != nil {
-			return nil, fmt.Errorf("Failed to create iterator, %w", err)
-		}
-
-	*/
 
 	// Enable custom placetypes
 
@@ -226,10 +149,9 @@ func NewSpatialApplication(ctx context.Context, opts *SpatialApplicationOptions)
 	sp := SpatialApplication{
 		SpatialDatabase:  spatial_db,
 		PropertiesReader: properties_reader,
-		// Iterator:         iter,
-		Timings: app_timings,
-		Monitor: m,
-		mu:      mu,
+		Timings:          app_timings,
+		Monitor:          m,
+		mu:               mu,
 	}
 
 	go func() {
@@ -264,50 +186,6 @@ func (p *SpatialApplication) Close(ctx context.Context) error {
 	return nil
 }
 
-/*
-
-// IndexPaths() will index 'paths' using p's `Iterator` instance storing each document in p's `SpatialDatabase` instance.
-func (p *SpatialApplication) IndexPaths(ctx context.Context, paths ...string) error {
-
-	go func() {
-
-		// TO DO: put this somewhere so that it can be triggered by signal(s)
-		// to reindex everything in bulk or incrementally
-
-		t1 := time.Now()
-
-		err := p.Iterator.IterateURIs(ctx, paths...)
-
-		if err != nil {
-			slog.Error("failed to index paths", "error", err)
-			os.Exit(1)
-		}
-
-		slog.Info("finished indexing", "time", time.Since(t1))
-		debug.FreeOSMemory()
-	}()
-
-	// set up some basic monitoring and feedback stuff
-
-	go func() {
-
-		c := time.Tick(1 * time.Second)
-
-		for _ = range c {
-
-			if !p.Iterator.IsIndexing() {
-				continue
-			}
-
-			slog.Info("indexing records", "indexed", p.Iterator.Seen)
-		}
-	}()
-
-	return nil
-}
-
-*/
-
 // IndexPaths() will index 'paths' using p's `Iterator` instance storing each document in p's `SpatialDatabase` instance.
 func (p *SpatialApplication) IndexDatabaseWithIterators(ctx context.Context, sources map[string][]string) error {
 
@@ -319,6 +197,7 @@ func (p *SpatialApplication) IndexDatabaseWithIterators(ctx context.Context, sou
 			return fmt.Errorf("Failed to index %s, %w", path, err)
 		}
 
+		go p.Monitor.Signal(ctx)
 		atomic.AddInt64(&p.indexed, 1)
 		return nil
 	}
@@ -346,4 +225,17 @@ func (p *SpatialApplication) IndexDatabaseWithIterators(ctx context.Context, sou
 	}
 
 	return nil
+}
+
+func (p *SpatialApplication) IsIndexing() bool {
+
+	if atomic.LoadInt64(&p.indexing) > 0 {
+		return true
+	}
+
+	return false
+}
+
+func (p *SpatialApplication) Indexed() int64 {
+	return atomic.LoadInt64(&p.indexed)
 }

--- a/cmd/pip/main.go
+++ b/cmd/pip/main.go
@@ -10,11 +10,9 @@ import (
 func main() {
 
 	ctx := context.Background()
-	logger := log.Default()
-
-	err := pip.Run(ctx, logger)
+	err := pip.Run(ctx)
 
 	if err != nil {
-		logger.Fatal(err)
+		log.Fatal(err)
 	}
 }

--- a/database/reader.go
+++ b/database/reader.go
@@ -20,7 +20,7 @@ func IndexDatabaseWithReader(ctx context.Context, db SpatialDatabase, r io.Reade
 		case "Polygon", "MultiPolygon":
 			return db.IndexFeature(ctx, body)
 		default:
-			slog.Warn("Record in unsupported geometry type, skipping", "type", geom_type)
+			slog.Debug("Record in unsupported geometry type, skipping", "type", geom_type)
 			return nil
 		}
 	}

--- a/database/rtree_test.go
+++ b/database/rtree_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -38,7 +39,13 @@ func TestSpatialDatabase(t *testing.T) {
 		t.Fatalf("Failed to create new spatial database, %v", err)
 	}
 
-	err = IndexDatabaseWithIterator(ctx, db, "directory://", "fixtures/microhoods")
+	path_microhoods, err := filepath.Abs("../fixtures/microhoods")
+
+	if err != nil {
+		t.Fatalf("Failed to derive path for microhoods, %v", err)
+	}
+
+	err = IndexDatabaseWithIterator(ctx, db, "directory://", path_microhoods)
 
 	if err != nil {
 		t.Fatalf("Failed to index spatial database, %v", err)

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -21,7 +21,7 @@ func FilterSPR(filters spatial.Filter, s spr.StandardPlacesResult) error {
 	pf, err := placetypes.NewPlacetypeFlag(s.Placetype())
 
 	if err != nil {
-		slog.Warn("Unable to parse placetype, skipping placetype filters", "id", s.Id(), s.Placetype(), "error", err)
+		slog.Warn("Unable to parse placetype, skipping placetype filters", "id", s.Id(), "placetype", s.Placetype(), "error", err)
 	} else {
 
 		ok = filters.HasPlacetypes(pf)

--- a/filter/query.go
+++ b/filter/query.go
@@ -34,25 +34,25 @@ func NewSPRFilterFromQuery(query url.Values) (spatial.Filter, error) {
 	is_deprecated, err := atoi(query["is_deprecated"])
 
 	if err != nil {
-		return nil, fmt.Errorf("Invalid ?is_deprecated= parameter, %w", err)		
+		return nil, fmt.Errorf("Invalid ?is_deprecated= parameter, %w", err)
 	}
 
 	is_ceased, err := atoi(query["is_ceased"])
 
 	if err != nil {
-		return nil, fmt.Errorf("Invalid ?is_ceased= parameter, %w", err)				
+		return nil, fmt.Errorf("Invalid ?is_ceased= parameter, %w", err)
 	}
 
 	is_superseded, err := atoi(query["is_superseded"])
 
 	if err != nil {
-		return nil, fmt.Errorf("Invalid ?is_superseded= parameter, %w", err)						
+		return nil, fmt.Errorf("Invalid ?is_superseded= parameter, %w", err)
 	}
 
 	is_superseding, err := atoi(query["is_superseding"])
 
 	if err != nil {
-		return nil, fmt.Errorf("Invalid ?is_superseding= parameter, %w", err)								
+		return nil, fmt.Errorf("Invalid ?is_superseding= parameter, %w", err)
 	}
 
 	inputs.IsCurrent = is_current

--- a/flags/iterator.go
+++ b/flags/iterator.go
@@ -7,6 +7,7 @@ import (
 
 const SEP_FRAGMENT string = "#"
 const SEP_PIPE string = "|"
+const SEP_SPACE string = " "
 
 type MultiIteratorURIFlag []*IteratorURIFlag
 
@@ -40,7 +41,7 @@ func (fl *MultiIteratorURIFlag) String() string {
 		str_flags[i] = iter_fl.String()
 	}
 
-	return strings.Join(str_flags, ",")
+	return strings.Join(str_flags, SEP_SPACE)
 }
 
 func (fl *MultiIteratorURIFlag) AsMap() map[string][]string {

--- a/flags/iterator.go
+++ b/flags/iterator.go
@@ -1,0 +1,55 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+)
+
+const SEP_FRAGMENT string = "#"
+const SEP_PIPE string = "|"
+
+type IteratorURIFlag struct {
+	iter_uri     string
+	iter_sources []string
+}
+
+func (fl *IteratorURIFlag) Key() string {
+	return fl.iter_uri
+}
+
+func (fl *IteratorURIFlag) Value() interface{} {
+	return fl.iter_sources
+}
+
+func (fl *IteratorURIFlag) String() string {
+
+	str_sources := strings.Join(fl.iter_sources, SEP_PIPE)
+
+	parts := []string{
+		fl.iter_uri,
+		str_sources,
+	}
+
+	return strings.Join(parts, SEP_FRAGMENT)
+}
+
+func (fl *IteratorURIFlag) Set(value string) error {
+
+	parts := strings.Split(value, SEP_FRAGMENT)
+
+	if len(parts) != 2 {
+		return fmt.Errorf("Invalid iterator URI")
+	}
+
+	iter_uri := parts[0]
+	iter_sources := strings.Split(parts[1], SEP_PIPE)
+
+	if len(iter_sources) == 0 {
+		return fmt.Errorf("Iterator URI missing sources")
+	}
+
+	fl.iter_uri = iter_uri
+	fl.iter_sources = iter_sources
+
+	return nil
+}

--- a/flags/iterator.go
+++ b/flags/iterator.go
@@ -32,7 +32,18 @@ func (fl *MultiIteratorURIFlag) Value() interface{} {
 	return fl
 }
 
-func (fl *MultiIteratorURIFlag) Map() map[string][]string {
+func (fl *MultiIteratorURIFlag) String() string {
+
+	str_flags := make([]string, len(*fl))
+
+	for i, iter_fl := range *fl {
+		str_flags[i] = iter_fl.String()
+	}
+
+	return strings.Join(str_flags, ",")
+}
+
+func (fl *MultiIteratorURIFlag) AsMap() map[string][]string {
 
 	iter_map := make(map[string][]string)
 

--- a/flags/iterator.go
+++ b/flags/iterator.go
@@ -1,5 +1,7 @@
 package flags
 
+// THERE IS A GOOD CHANGE THIS WILL BE MOVED IN TO THE whosonfirst/go-whosonfirst-iterate PACKAGE...
+
 import (
 	"fmt"
 	"strings"
@@ -8,6 +10,53 @@ import (
 const SEP_FRAGMENT string = "#"
 const SEP_PIPE string = "|"
 const SEP_SPACE string = " "
+const SEP_CSV string = ","
+
+type IteratorURIFlag struct {
+	iter_uri     string
+	iter_sources []string
+}
+
+func (fl *IteratorURIFlag) Key() string {
+	return fl.iter_uri
+}
+
+func (fl *IteratorURIFlag) Value() interface{} {
+	return fl.iter_sources
+}
+
+func (fl *IteratorURIFlag) String() string {
+
+	str_sources := strings.Join(fl.iter_sources, SEP_PIPE)
+
+	parts := []string{
+		fl.iter_uri,
+		str_sources,
+	}
+
+	return strings.Join(parts, SEP_FRAGMENT)
+}
+
+func (fl *IteratorURIFlag) Set(value string) error {
+
+	parts := strings.Split(value, SEP_FRAGMENT)
+
+	if len(parts) != 2 {
+		return fmt.Errorf("Invalid iterator URI")
+	}
+
+	iter_uri := parts[0]
+	iter_sources := strings.Split(parts[1], SEP_PIPE)
+
+	if len(iter_sources) == 0 {
+		return fmt.Errorf("Iterator URI missing sources")
+	}
+
+	fl.iter_uri = iter_uri
+	fl.iter_sources = iter_sources
+
+	return nil
+}
 
 type MultiIteratorURIFlag []*IteratorURIFlag
 
@@ -59,48 +108,58 @@ func (fl *MultiIteratorURIFlag) AsMap() map[string][]string {
 	return iter_map
 }
 
-type IteratorURIFlag struct {
-	iter_uri     string
-	iter_sources []string
-}
+type MultiCSVIteratorURIFlag []*IteratorURIFlag
 
-func (fl *IteratorURIFlag) Key() string {
-	return fl.iter_uri
-}
+func (fl *MultiCSVIteratorURIFlag) Set(value string) error {
 
-func (fl *IteratorURIFlag) Value() interface{} {
-	return fl.iter_sources
-}
+	for _, str_fl := range strings.Split(value, SEP_CSV) {
 
-func (fl *IteratorURIFlag) String() string {
+		iter_fl := new(MultiIteratorURIFlag)
 
-	str_sources := strings.Join(fl.iter_sources, SEP_PIPE)
+		err := iter_fl.Set(str_fl)
 
-	parts := []string{
-		fl.iter_uri,
-		str_sources,
+		if err != nil {
+			return err
+		}
+
+		for _, iter_v_fl := range *iter_fl {
+			*fl = append(*fl, iter_v_fl)
+		}
 	}
-
-	return strings.Join(parts, SEP_FRAGMENT)
-}
-
-func (fl *IteratorURIFlag) Set(value string) error {
-
-	parts := strings.Split(value, SEP_FRAGMENT)
-
-	if len(parts) != 2 {
-		return fmt.Errorf("Invalid iterator URI")
-	}
-
-	iter_uri := parts[0]
-	iter_sources := strings.Split(parts[1], SEP_PIPE)
-
-	if len(iter_sources) == 0 {
-		return fmt.Errorf("Iterator URI missing sources")
-	}
-
-	fl.iter_uri = iter_uri
-	fl.iter_sources = iter_sources
 
 	return nil
+}
+
+func (fl *MultiCSVIteratorURIFlag) Key() string {
+	return ""
+}
+
+func (fl *MultiCSVIteratorURIFlag) Value() interface{} {
+	return fl
+}
+
+func (fl *MultiCSVIteratorURIFlag) String() string {
+
+	str_flags := make([]string, len(*fl))
+
+	for i, iter_fl := range *fl {
+		str_flags[i] = iter_fl.String()
+	}
+
+	return strings.Join(str_flags, SEP_CSV)
+}
+
+func (fl *MultiCSVIteratorURIFlag) AsMap() map[string][]string {
+
+	iter_map := make(map[string][]string)
+
+	for _, iter_fl := range *fl {
+
+		iter_uri := iter_fl.Key()
+		iter_sources := iter_fl.Value().([]string)
+
+		iter_map[iter_uri] = iter_sources
+	}
+
+	return iter_map
 }

--- a/flags/iterator.go
+++ b/flags/iterator.go
@@ -4,13 +4,29 @@ package flags
 
 import (
 	"fmt"
+	"sort"
 	"strings"
+
+	"github.com/whosonfirst/go-whosonfirst-iterate/v2/emitter"
 )
 
 const SEP_FRAGMENT string = "#"
 const SEP_PIPE string = "|"
 const SEP_SPACE string = " "
 const SEP_CSV string = ","
+
+// IteratorURIDescription returns a string describing the use the of the `IteratorURIFlag` flag.
+func IteratorURIFlagDescription() string {
+
+	modes := emitter.Schemes()
+	sort.Strings(modes)
+
+	valid_modes := strings.Join(modes, ", ")
+
+	desc := fmt.Sprintf("URIs take the form of {ITERATOR_URI} + \"#\" + {PIPE-SEPARATED LIST OF ITERATOR SOURCES}. Where {ITERATOR_URI} is expected to be a registered whosonfirst/go-whosonfirst-iterate/v2 iterator (emitter) URI and {ITERATOR SOURCES} are valid input paths for that iterator. Supported whosonfirst/go-whosonfirst-iterate/v2 iterator schemes are: %s.", valid_modes)
+
+	return desc
+}
 
 // IteratorURIFlag parses a string in to components necessary for use with a `whosonfirst/go-whosonfirst-iterate/v2/iterator.Iterator` instance.
 // Flags are expected to take the form of:

--- a/flags/iterator.go
+++ b/flags/iterator.go
@@ -12,31 +12,27 @@ const SEP_PIPE string = "|"
 const SEP_SPACE string = " "
 const SEP_CSV string = ","
 
+// IteratorURIFlag parses a string in to components necessary for use with a `whosonfirst/go-whosonfirst-iterate/v2/iterator.Iterator` instance.
+// Flags are expected to take the form of:
+//
+//	{ITERATOR_URI_STRING} + "#" + {PIPE_SEPARATED_LIST_OF_ITERATOR_SOURCES}
+//
+// Where:
+// * `{ITERATOR_URI_STRING}` is a URI that can be passed to the `iterator.NewIterator` constructor.
+// * `{PIPE_SEPARATED_LIST_OF_ITERATOR_SOURCES}` is a list of one or more paths (URIs) to be passed to the `iterator.IterateURIs` method.
 type IteratorURIFlag struct {
 	iter_uri     string
 	iter_sources []string
 }
 
-func (fl *IteratorURIFlag) Key() string {
-	return fl.iter_uri
-}
-
-func (fl *IteratorURIFlag) Value() interface{} {
-	return fl.iter_sources
-}
-
-func (fl *IteratorURIFlag) String() string {
-
-	str_sources := strings.Join(fl.iter_sources, SEP_PIPE)
-
-	parts := []string{
-		fl.iter_uri,
-		str_sources,
-	}
-
-	return strings.Join(parts, SEP_FRAGMENT)
-}
-
+// Set parses 'value' in to components necessary for use with a `whosonfirst/go-whosonfirst-iterate/v2/iterator.Iterator` instance.
+// 'value' is expected to take the form of:
+//
+//	{ITERATOR_URI_STRING} + "#" + {PIPE_SEPARATED_LIST_OF_ITERATOR_SOURCES}
+//
+// Where:
+// * `{ITERATOR_URI_STRING}` is a URI that can be passed to the `iterator.NewIterator` constructor.
+// * `{PIPE_SEPARATED_LIST_OF_ITERATOR_SOURCES}` is a list of one or more paths (URIs) to be passed to the `iterator.IterateURIs` method.
 func (fl *IteratorURIFlag) Set(value string) error {
 
 	parts := strings.Split(value, SEP_FRAGMENT)
@@ -58,6 +54,30 @@ func (fl *IteratorURIFlag) Set(value string) error {
 	return nil
 }
 
+// Key returns the value of the `{ITERATOR_URI_STRING}` string.
+func (fl *IteratorURIFlag) Key() string {
+	return fl.iter_uri
+}
+
+// Values returns the list of URIs defined in the `{PIPE_SEPARATED_LIST_OF_ITERATOR_SOURCES}` string.
+func (fl *IteratorURIFlag) Value() interface{} {
+	return fl.iter_sources
+}
+
+// String returns value of the flag.
+func (fl *IteratorURIFlag) String() string {
+
+	str_sources := strings.Join(fl.iter_sources, SEP_PIPE)
+
+	parts := []string{
+		fl.iter_uri,
+		str_sources,
+	}
+
+	return strings.Join(parts, SEP_FRAGMENT)
+}
+
+// MultiIteratorURIFlag is a flag that can hold multiple `IteratorURIFlag` instances.
 type MultiIteratorURIFlag []*IteratorURIFlag
 
 func (fl *MultiIteratorURIFlag) Set(value string) error {
@@ -108,6 +128,8 @@ func (fl *MultiIteratorURIFlag) AsMap() map[string][]string {
 	return iter_map
 }
 
+// MultiCSVIteratorURIFlag is a flag that can hold multiple `IteratorURIFlag` instances
+// defined using a single comma-separated string.
 type MultiCSVIteratorURIFlag []*IteratorURIFlag
 
 func (fl *MultiCSVIteratorURIFlag) Set(value string) error {

--- a/flags/iterator.go
+++ b/flags/iterator.go
@@ -8,6 +8,45 @@ import (
 const SEP_FRAGMENT string = "#"
 const SEP_PIPE string = "|"
 
+type MultiIteratorURIFlag []*IteratorURIFlag
+
+func (fl *MultiIteratorURIFlag) Set(value string) error {
+
+	iter_fl := new(IteratorURIFlag)
+
+	err := iter_fl.Set(value)
+
+	if err != nil {
+		return err
+	}
+
+	*fl = append(*fl, iter_fl)
+	return nil
+}
+
+func (fl *MultiIteratorURIFlag) Key() string {
+	return ""
+}
+
+func (fl *MultiIteratorURIFlag) Value() interface{} {
+	return fl
+}
+
+func (fl *MultiIteratorURIFlag) Map() map[string][]string {
+
+	iter_map := make(map[string][]string)
+
+	for _, iter_fl := range *fl {
+
+		iter_uri := iter_fl.Key()
+		iter_sources := iter_fl.Value().([]string)
+
+		iter_map[iter_uri] = iter_sources
+	}
+
+	return iter_map
+}
+
 type IteratorURIFlag struct {
 	iter_uri     string
 	iter_sources []string

--- a/flags/iterator_test.go
+++ b/flags/iterator_test.go
@@ -1,0 +1,68 @@
+package flags
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIteratorURIFlag(t *testing.T) {
+
+	str_flag := "repo://#/usr/local/data/sfomuseum-data-architecture"
+
+	fl := new(IteratorURIFlag)
+
+	err := fl.Set(str_flag)
+
+	if err != nil {
+		t.Fatalf("Failed to create flag, %v", err)
+	}
+
+	if fl.String() != str_flag {
+		t.Fatalf("Invalid string value for flag: %s", fl.String())
+	}
+}
+
+func TestMultiIteratorURIFlag(t *testing.T) {
+
+	str_flags := []string{
+		"repo://#/usr/local/data/sfomuseum-data-architecture",
+		"featurecollection://#/usr/local/data/sfomuseum.geojson",
+	}
+
+	fl := new(MultiIteratorURIFlag)
+
+	for _, str_flag := range str_flags {
+
+		err := fl.Set(str_flag)
+
+		if err != nil {
+			t.Fatalf("Failed to add multi flag '%s', %v", str_flag, err)
+		}
+	}
+
+	if fl.String() != strings.Join(str_flags, SEP_SPACE) {
+		t.Fatalf("Invalid string value for flag: %s", fl.String())
+	}
+}
+
+func TestMultiCSVIteratorURIFlag(t *testing.T) {
+
+	str_flags := []string{
+		"repo://#/usr/local/data/sfomuseum-data-architecture",
+		"featurecollection://#/usr/local/data/sfomuseum.geojson",
+	}
+
+	csv_flag := strings.Join(str_flags, SEP_CSV)
+
+	fl := new(MultiCSVIteratorURIFlag)
+
+	err := fl.Set(csv_flag)
+
+	if err != nil {
+		t.Fatalf("Failed to add CSV flag, %v", err)
+	}
+
+	if fl.String() != csv_flag {
+		t.Fatalf("Invalid string value for flag: %s", fl.String())
+	}
+}


### PR DESCRIPTION
* Update to use `flags.IteratorURIFlag` to define source and target URIs. This introduces backwards incompatible changes in the input expected by the `-iterator-uri` flag(s) used by tools defined in `cmd`
* Remove `IsWhosOnFirst` and `Iterator` properties from `application.SpatialApplication`. These are backwards incompatible changes.
* Remove `IndexPaths` method from `application.SpatialApplication`
* Add `IndexDatabaseWithIterators` method to `application.SpatialApplication`
* Add `IsIndexing` and `Indexed` methods to `application.SpatialApplication`
* Remove use of `log.Logger` in `Run*` methods.
* This release is backwards incompatible.