### PR TITLE
Add `query.MapTileSpatialQuery` type

### DIFF
--- a/maptile/maptile.go
+++ b/maptile/maptile.go
@@ -17,7 +17,7 @@ import (
 // PointInPolygonCandidateFeaturessFromTile will derive the bounds of map tile 't' and use that geometry
 // to perform an "intersects" query against database 'db'. The result set will then be transformed in to
 // GeoJSON FeatureCollection where each feature's geometry will be trim to extent of map tile 't'.
-func PointInPolygonCandidateFeaturessFromTile(ctx context.Context, db database.SpatialDatabase, q *query.SpatialQuery, t orb_maptile.Tile) (*geojson.FeatureCollection, error) {
+func PointInPolygonCandidateFeaturessFromTile(ctx context.Context, db database.SpatialDatabase, q *query.SpatialQuery, t *orb_maptile.Tile) (*geojson.FeatureCollection, error) {
 
 	tile_bounds := t.Bound()
 	tile_geom := tile_bounds.ToPolygon()

--- a/maptile/maptile_test.go
+++ b/maptile/maptile_test.go
@@ -72,7 +72,7 @@ func TestPointInPolygonCandidateFeaturessFromTile(t *testing.T) {
 
 		spatial_q := &query.SpatialQuery{}
 
-		fc, err := PointInPolygonCandidateFeaturessFromTile(ctx, db, spatial_q, map_t)
+		fc, err := PointInPolygonCandidateFeaturessFromTile(ctx, db, spatial_q, &map_t)
 
 		if err != nil {
 			t.Fatalf("Failed to derive feature collection from tile query, %v", err)


### PR DESCRIPTION
* Add `query.MapTileSpatialQuery` type
* Update `maptile.PointInPolygonCandidateFeaturessFromTile` method signature to take `maptile.Tile` by reference
* This release is NOT backwards compatible